### PR TITLE
update vite config to works with secure development server

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -29,7 +29,7 @@ export default defineConfig({
         }),
         laravel(['resources/css/app.css', 'resources/js/app.js']),
         {
-            valetTls: 'atlas.sng.local',
+            valetTls: host,
             refresh: true,
         },
     ],

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,11 @@
+import fs from 'fs'
 import laravel from 'laravel-vite-plugin'
 import vue from '@vitejs/plugin-vue'
 import { defineConfig } from 'vite'
+import { homedir } from 'os'
+import { resolve } from 'path'
+
+let host = 'atlas.sng.local'
 
 export default defineConfig({
     plugins: [
@@ -24,16 +29,32 @@ export default defineConfig({
         }),
         laravel(['resources/css/app.css', 'resources/js/app.js']),
         {
-            name: 'blade',
-            handleHotUpdate({ file, server }) {
-                if (file.endsWith('.blade.php')) {
-                    server.ws.send({
-                        type: 'full-reload',
-                        path: '*',
-                    })
-                }
-            },
             valetTls: 'atlas.sng.local',
+            refresh: true,
         },
     ],
+    server: detectServerConfig(host),
 })
+
+// credits: https://freek.dev/2276-making-vite-and-valet-play-nice-together
+function detectServerConfig(host) {
+    let keyPath = resolve(homedir(), `.config/valet/Certificates/${host}.key`)
+    let certificatePath = resolve(homedir(), `.config/valet/Certificates/${host}.crt`)
+
+    if (!fs.existsSync(keyPath)) {
+        return {}
+    }
+
+    if (!fs.existsSync(certificatePath)) {
+        return {}
+    }
+
+    return {
+        hmr: { host },
+        host,
+        https: {
+            key: fs.readFileSync(keyPath),
+            cert: fs.readFileSync(certificatePath),
+        },
+    }
+}


### PR DESCRIPTION
implemented this https://freek.dev/2276-making-vite-and-valet-play-nice-together to fix `WebSocket connection failed` 
+ to enable testing on ios simulator ;)

@rastislav-chynoransky please test for your local dvelopment
also I can imagine to use `loadEnv` in the future to get current `host`