### PR TITLE
Nsng 172 format text in section

### DIFF
--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -3,7 +3,6 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Str;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
 use Spatie\Translatable\HasTranslations;
@@ -22,13 +21,5 @@ class Story extends Model implements HasMedia
     public function links()
     {
         return $this->belongsToMany(StoryLink::class)->orderByPivot('ord');
-    }
-
-    protected function getTextAttribute($value)
-    {
-        return Str::of($value)
-            ->replaceMatches('/\*\*(\s*)(.*?)(\s*)\*\*/', '$1**$2**$3')
-            ->replaceMatches('/_(\s*)(.*?)(\s*)_/', '$1_$2_$3')
-            ->replaceMatches('/~~(\s*)(.*?)(\s*)~~/', '$1~~$2~~$3');
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -63,7 +63,8 @@ class AppServiceProvider extends ServiceProvider
                     'renderer' => [
                         'soft_break' => '<br />',
                     ],
-                ]);
+                ])
+                ->remove('**');
         });
 
         Stringable::macro('markdownWithLineBreaks', function () {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -33,7 +33,7 @@ class AppServiceProvider extends ServiceProvider
         foreach ([Http::class, PendingRequest::class] as $class) {
             $class::macro(
                 'webumenia',
-                fn() => $class
+                fn () => $class
                     ::withHeaders([
                         'Accept-Language' => app()->getLocale(),
                     ])
@@ -43,7 +43,7 @@ class AppServiceProvider extends ServiceProvider
 
         Http::macro(
             'vimeo',
-            fn() => Http::withHeaders([
+            fn () => Http::withHeaders([
                 'Authorization' => sprintf('bearer %s', config('services.vimeo.access_token')),
                 'Accept' => sprintf('application/vnd.vimeo.*+json;version=%s', config('services.vimeo.api_version')),
             ])->baseUrl(config('services.vimeo.api'))
@@ -55,11 +55,15 @@ class AppServiceProvider extends ServiceProvider
         ]);
 
         Str::macro('markdownWithLineBreaks', function ($value) {
-            return str($value)->markdown([
-                'renderer' => [
-                    'soft_break' => '<br />',
-                ],
-            ]);
+            return Str::of($value)
+                ->replaceMatches('/\*\*(\s*)(.*?)(\s*)\*\*/', '$1**$2**$3')
+                ->replaceMatches('/_(\s*)(.*?)(\s*)_/', '$1_$2_$3')
+                ->replaceMatches('/~~(\s*)(.*?)(\s*)~~/', '$1~~$2~~$3')
+                ->markdown([
+                    'renderer' => [
+                        'soft_break' => '<br />',
+                    ],
+                ]);
         });
 
         Stringable::macro('markdownWithLineBreaks', function () {


### PR DESCRIPTION
![Snímka obrazovky 2022-12-19 o 12 47 08](https://user-images.githubusercontent.com/2682941/208419601-69747332-d4dc-4d2b-98cc-2d3b5574db96.png)


leftover `**` applies for previously removed text - but with still applied formating on empty space - or even nothing. 
this fix that