### PR TITLE
fix import sections to include only published (and imported) items

### DIFF
--- a/app/Jobs/ImportSectionsJob.php
+++ b/app/Jobs/ImportSectionsJob.php
@@ -44,7 +44,9 @@ class ImportSectionsJob implements ShouldQueue
             $airtableIds = Arr::get($record, 'fields.Diela sekcie', []);
             $itemsLookup = Item::whereIn('airtable_id', $airtableIds)->pluck('id', 'airtable_id');
             $section->items()->sync(
-                collect($airtableIds)->mapWithKeys(
+                collect($airtableIds)
+                ->filter(fn($airtableId) => $itemsLookup->has($airtableId))                
+                ->mapWithKeys(
                     fn ($airtableId, $index) => [
                         $itemsLookup[$airtableId] => [
                             'ord' => $index,


### PR DESCRIPTION
now we import only "published" items. 
what causes `Undefined array key "..."` warning 
(and `Integrity constraint violation` exception)
