### PR TITLE
chore: fix style for empty sections

### DIFF
--- a/resources/js/views/SectionDetail.vue
+++ b/resources/js/views/SectionDetail.vue
@@ -1,8 +1,8 @@
 <template>
     <div class="relative h-full border-black pb-24" v-if="section">
         <div class="h-full bg-black p-4">
-            <img class="h-9 w-9" :src="`/img/${section.code}.svg`" :alt="section.code" />
-            <p class="mb-2 mt-4 font-bold text-green">
+            <img class="h-9 w-9 mb-4" :src="`/img/${section.code}.svg`" :alt="section.code" />
+            <p v-if="section.items.length" class="mb-2 font-bold text-green">
                 {{ $t('Group of :count artworks', { count: section.items.length }) }}
             </p>
             <h2 class="text-1.5xl font-bold text-white">{{ section.title }}</h2>
@@ -13,7 +13,7 @@
             </div>
             <div class="my-4 space-y-4" v-html="section.description"></div>
 
-            <p class="mb-2 font-bold">{{ $t('More about artworks in the group') }}</p>
+            <p v-if="section.items.length" class="mb-2 font-bold">{{ $t('More about artworks in the group') }}</p>
             <div class="flex flex-col space-y-3">
                 <router-link
                     v-for="item in section.items"


### PR DESCRIPTION
Quick fix:
Handle 0 items collections.

(Looks a bit disappointing, IMHO better than broken)
![Snímka obrazovky 2023-06-27 o 15 34 54](https://github.com/SlovakNationalGallery/atlas.sng.sk/assets/28804184/798e4b26-d1c4-4131-8590-99c438835616)
